### PR TITLE
Fixed an issue in the data reducer that wiped savedArray, savedFilter…

### DIFF
--- a/src/redux/reducers/dataReducer.js
+++ b/src/redux/reducers/dataReducer.js
@@ -31,7 +31,13 @@ const dataReducer = (state = INITIAL_STATE, action) => {
       };
     case DATA.FETCH_API_FAILURE:
       return {
-        ...INITIAL_STATE,
+        ...state,
+        loadingData: false,
+        characterCount: 0,
+        nextEndpoint: '',
+        previousEndpoint: '',
+        searchArray: [],
+        searchText: '',
         error: action.payload,
       };
     case DATA.SAVE_CHARACTER:


### PR DESCRIPTION
Fixed an issue in the data reducer that wiped savedArray, savedFilter and characterSelected stored values when the api fetch failed.
Now DATA.FETCH_API_FAILURE will only wipe the information that should be received from the api request, reset loadingData bool, and update the error message.